### PR TITLE
Set originating element(s) when generating code

### DIFF
--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessor.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/ExposedApplicationAnnotationProcessor.java
@@ -3,8 +3,10 @@ package fr.vidal.oss.jax_rs_linker;
 import com.google.auto.service.AutoService;
 import fr.vidal.oss.jax_rs_linker.api.ExposedApplication;
 import fr.vidal.oss.jax_rs_linker.errors.CompilationError;
+import fr.vidal.oss.jax_rs_linker.model.ClassNames;
 import fr.vidal.oss.jax_rs_linker.visitor.ApplicationNameVisitor;
 import fr.vidal.oss.jax_rs_linker.writer.ApplicationNameWriter;
+import fr.vidal.oss.jax_rs_linker.writer.ContextPathHolderWriter;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
@@ -55,15 +57,16 @@ public class ExposedApplicationAnnotationProcessor extends AbstractProcessor {
             if (!name.isPresent()) {
                 return false;
             }
-            write(name.get());
+            write(name.get(), maybeExposedApplication.get());
         }
 
         return false;
     }
 
-    private void write(String name) {
+    private void write(String name, TypeElement originatingElement) {
         try {
-            new ApplicationNameWriter(filer).write(name);
+            new ApplicationNameWriter(filer).write(name, originatingElement);
+            new ContextPathHolderWriter(filer).write(ClassNames.CONTEXT_PATH_HOLDER, originatingElement);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/functions/MappingToDot.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/functions/MappingToDot.java
@@ -4,6 +4,7 @@ import fr.vidal.oss.jax_rs_linker.model.Api;
 import fr.vidal.oss.jax_rs_linker.model.ApiLink;
 import fr.vidal.oss.jax_rs_linker.model.ApiLinkType;
 import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
 
 import javax.annotation.Nullable;
@@ -12,13 +13,13 @@ import java.util.function.Function;
 
 import static java.lang.String.format;
 
-public enum MappingToDot implements Function<Map.Entry<ClassName, Mapping>, String> {
+public enum MappingToDot implements Function<Map.Entry<ClassNameGeneration, Mapping>, String> {
 
     TO_DOT_STATEMENT;
 
     @Nullable
     @Override
-    public String apply(Map.Entry<ClassName, Mapping> input) {
+    public String apply(Map.Entry<ClassNameGeneration, Mapping> input) {
         Api api = input.getValue().getApi();
         ApiLink apiLink = api.getApiLink();
         if (apiLink.getApiLinkType() != ApiLinkType.SUB_RESOURCE) {
@@ -26,7 +27,7 @@ public enum MappingToDot implements Function<Map.Entry<ClassName, Mapping>, Stri
         }
         return format(
                 "\t%s -> %s [label=\"%s\"];",
-                escape(input.getKey()),
+                escape(input.getKey().getClassName()),
                 escape(apiLink.getTarget().get()),
                 api.getApiPath().getPath()
         );

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/ClassNameGeneration.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/ClassNameGeneration.java
@@ -1,0 +1,76 @@
+package fr.vidal.oss.jax_rs_linker.model;
+
+import javax.lang.model.element.TypeElement;
+import java.util.Objects;
+
+public class ClassNameGeneration implements Comparable<ClassNameGeneration> {
+
+    private final ClassName className;
+    private final TypeElement originatingElement;
+
+    public ClassNameGeneration(ClassName className, TypeElement originatingElement) {
+        this.className = className;
+        this.originatingElement = originatingElement;
+    }
+
+    public ClassNameGeneration(TypeElement originatingElement) {
+        this.className = ClassName.valueOf(originatingElement.getQualifiedName().toString());
+        this.originatingElement = originatingElement;
+    }
+
+    public ClassNameGeneration append(String suffix) {
+        return new ClassNameGeneration(ClassName.valueOf(className.fullyQualifiedName() + suffix), originatingElement);
+    }
+
+    public String className() {
+        String name = className.fullyQualifiedName();
+        if (!name.contains(".")) {
+            return name;
+        }
+        return name.substring(name.lastIndexOf('.') + 1);
+    }
+
+    public String packageName() {
+        String name = className.fullyQualifiedName();
+        if (!name.contains(".")) {
+            return "";
+        }
+        return name.substring(0, name.lastIndexOf('.'));
+    }
+
+    public ClassName getClassName() {
+        return className;
+    }
+
+    public TypeElement getOriginatingElement() {
+        return originatingElement;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, originatingElement);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final ClassNameGeneration other = (ClassNameGeneration) obj;
+        return Objects.equals(this.className, other.className)
+            && Objects.equals(this.originatingElement, other.originatingElement);
+    }
+
+    @Override
+    public String toString() {
+        return className.fullyQualifiedName();
+    }
+
+    @Override
+    public int compareTo(ClassNameGeneration other) {
+        return className.fullyQualifiedName().compareTo(other.getClassName().fullyQualifiedName());
+    }
+}

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/ClassNames.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/ClassNames.java
@@ -1,0 +1,10 @@
+package fr.vidal.oss.jax_rs_linker.model;
+
+public class ClassNames {
+
+    public static final ClassName CONTEXT_PATH_HOLDER = ClassName.valueOf("fr.vidal.oss.jax_rs_linker.ContextPathHolder");
+
+    private ClassNames() {
+        // Hide me!
+    }
+}

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/JavaLocation.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/model/JavaLocation.java
@@ -4,17 +4,17 @@ import java.util.Objects;
 
 public class JavaLocation {
 
-    private final ClassName className;
+    private final ClassNameGeneration classNameGeneration;
     private final String methodName;
 
 
-    public JavaLocation(ClassName className, String methodName) {
-        this.className = className;
+    public JavaLocation(ClassNameGeneration classNameGeneration, String methodName) {
+        this.classNameGeneration = classNameGeneration;
         this.methodName = methodName;
     }
 
-    public ClassName getClassName() {
-        return className;
+    public ClassNameGeneration getClassNameGeneration() {
+        return classNameGeneration;
     }
 
     public String getMethodName() {
@@ -24,7 +24,7 @@ public class JavaLocation {
 
     @Override
     public int hashCode() {
-        return Objects.hash(className, methodName);
+        return Objects.hash(classNameGeneration, methodName);
     }
 
     @Override
@@ -36,12 +36,12 @@ public class JavaLocation {
             return false;
         }
         final JavaLocation other = (JavaLocation) obj;
-        return Objects.equals(this.className, other.className)
+        return Objects.equals(this.classNameGeneration, other.classNameGeneration)
                 && Objects.equals(this.methodName, other.methodName);
     }
 
     @Override
     public String toString() {
-        return String.format("%s#%s", className, methodName);
+        return String.format("%s#%s", classNameGeneration, methodName);
     }
 }

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/parser/ElementParser.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/parser/ElementParser.java
@@ -9,6 +9,7 @@ import fr.vidal.oss.jax_rs_linker.model.ApiLinkType;
 import fr.vidal.oss.jax_rs_linker.model.ApiPath;
 import fr.vidal.oss.jax_rs_linker.model.ApiQuery;
 import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.HttpVerb;
 import fr.vidal.oss.jax_rs_linker.model.JavaLocation;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
@@ -143,7 +144,7 @@ public class ElementParser {
         }
 
         checkArgument(link.getApiLinkType() == ApiLinkType.SELF, "SubResource should define a target");
-        ClassName className = mapping.getJavaLocation().getClassName();
+        ClassName className = mapping.getJavaLocation().getClassNameGeneration().getClassName();
         if (workLoad.isCompleted(className)) {
             return Optional.of(CompilationError.TOO_MANY_SELF);
         }
@@ -170,9 +171,9 @@ public class ElementParser {
         return new Api(httpVerb, link, apiPath, apiQuery);
     }
 
-    private ClassName className(ExecutableElement element) {
+    private ClassNameGeneration className(ExecutableElement element) {
         TypeElement classElement = (TypeElement) element.getEnclosingElement();
-        return ClassName.valueOf(classElement.getQualifiedName().toString());
+        return new ClassNameGeneration(classElement);
     }
 
     private Optional<Mapping> compilationError(Element element, String errorMsg) {

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/parser/ResourceGraphValidator.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/parser/ResourceGraphValidator.java
@@ -2,7 +2,7 @@ package fr.vidal.oss.jax_rs_linker.parser;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
-import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
 
 import javax.annotation.processing.Messager;
@@ -23,8 +23,8 @@ public class ResourceGraphValidator {
         this.messager = messager;
     }
 
-    public boolean validateMappings(Multimap<ClassName, Mapping> roundElements) {
-        Collection<ClassName> classesWithoutSelf = classesWithoutSelf(roundElements);
+    public boolean validateMappings(Multimap<ClassNameGeneration, Mapping> roundElements) {
+        Collection<ClassNameGeneration> classesWithoutSelf = classesWithoutSelf(roundElements);
         if (classesWithoutSelf.isEmpty()) {
             return true;
         }
@@ -35,7 +35,7 @@ public class ResourceGraphValidator {
 
 
 
-    private Collection<ClassName> classesWithoutSelf(Multimap<ClassName, Mapping> roundElements) {
+    private Collection<ClassNameGeneration> classesWithoutSelf(Multimap<ClassNameGeneration, Mapping> roundElements) {
         return roundElements.asMap().entrySet().stream()
             .filter(classMappings -> classMappings.getValue().stream().noneMatch(HAS_SELF))
             .map(Map.Entry::getKey)

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ApplicationNameWriter.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ApplicationNameWriter.java
@@ -4,6 +4,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.TypeElement;
 import java.io.IOException;
 
 import static com.squareup.javapoet.MethodSpec.methodBuilder;
@@ -18,9 +19,10 @@ public class ApplicationNameWriter {
         this.filer = filer;
     }
 
-    public void write(String name) throws IOException {
+    public void write(String name, TypeElement originatingElement) throws IOException {
 
         TypeSpec type = classBuilder("ApplicationName")
+            .addOriginatingElement(originatingElement)
             .addModifiers(PUBLIC, FINAL)
             .addMethod(methodBuilder("get")
                 .returns(String.class)

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ContextPathHolderWriter.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/ContextPathHolderWriter.java
@@ -11,6 +11,7 @@ import fr.vidal.oss.jax_rs_linker.servlet.ContextPaths;
 
 import javax.annotation.Generated;
 import javax.annotation.processing.Filer;
+import javax.lang.model.element.TypeElement;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
@@ -30,8 +31,9 @@ public class ContextPathHolderWriter {
         this.filer = filer;
     }
 
-    public void write(ClassName linkers) throws IOException {
+    public void write(ClassName linkers, TypeElement originatingElement) throws IOException {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(linkers.className())
+            .addOriginatingElement(originatingElement)
             .addModifiers(PUBLIC, FINAL)
             .addSuperinterface(ServletContextListener.class)
             .addAnnotation(AnnotationSpec.builder(WebListener.class).build())

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/DotFileWriter.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/DotFileWriter.java
@@ -3,7 +3,7 @@ package fr.vidal.oss.jax_rs_linker.writer;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
-import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
 
 import java.io.IOException;
@@ -22,7 +22,7 @@ public class DotFileWriter implements AutoCloseable {
         this.writer = writer;
     }
 
-    public void write(Multimap<ClassName, Mapping> elements) {
+    public void write(Multimap<ClassNameGeneration, Mapping> elements) {
         try {
             writer.append(Joiner.on("\n").join(graph(elements)));
         } catch (IOException e) {
@@ -39,7 +39,7 @@ public class DotFileWriter implements AutoCloseable {
         }
     }
 
-    private Iterable<String> graph(Multimap<ClassName, Mapping> elements) {
+    private Iterable<String> graph(Multimap<ClassNameGeneration, Mapping> elements) {
         return ImmutableList.<String>builder()
             .add("dinetwork {")
             .addAll(mappings(elements))
@@ -47,7 +47,7 @@ public class DotFileWriter implements AutoCloseable {
             .build();
     }
 
-    private Iterable<String> mappings(Multimap<ClassName, Mapping> elements) {
+    private Iterable<String> mappings(Multimap<ClassNameGeneration, Mapping> elements) {
         return elements.entries().stream()
             .map(TO_DOT_STATEMENT)
             .filter(Objects::nonNull)

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/PathParamsEnumWriter.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/PathParamsEnumWriter.java
@@ -7,7 +7,7 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import fr.vidal.oss.jax_rs_linker.LinkerAnnotationProcessor;
 import fr.vidal.oss.jax_rs_linker.api.PathParameters;
-import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
 import fr.vidal.oss.jax_rs_linker.model.PathParameter;
 
@@ -34,9 +34,10 @@ public class PathParamsEnumWriter {
         this.filer = filer;
     }
 
-    public void write(ClassName generatedClass, Collection<Mapping> mappings) throws IOException {
+    public void write(ClassNameGeneration generatedClass, Collection<Mapping> mappings) throws IOException {
 
         TypeSpec.Builder typeBuilder = TypeSpec.enumBuilder(generatedClass.className())
+            .addOriginatingElement(generatedClass.getOriginatingElement())
             .addModifiers(PUBLIC)
             .addSuperinterface(PathParameters.class)
             .addAnnotation(AnnotationSpec.builder(Generated.class)

--- a/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/QueryParamsEnumWriter.java
+++ b/jax-rs-linker-processor/src/main/java/fr/vidal/oss/jax_rs_linker/writer/QueryParamsEnumWriter.java
@@ -7,7 +7,7 @@ import com.squareup.javapoet.TypeSpec;
 import fr.vidal.oss.jax_rs_linker.LinkerAnnotationProcessor;
 import fr.vidal.oss.jax_rs_linker.api.QueryParameters;
 import fr.vidal.oss.jax_rs_linker.functions.MappingToQueryParameters;
-import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
 import fr.vidal.oss.jax_rs_linker.model.Mapping;
 import fr.vidal.oss.jax_rs_linker.model.QueryParameter;
 
@@ -30,8 +30,9 @@ public class QueryParamsEnumWriter {
         this.filer = filer;
     }
 
-    public void write(ClassName generatedClass, Collection<Mapping> mappings) throws IOException {
+    public void write(ClassNameGeneration generatedClass, Collection<Mapping> mappings) throws IOException {
         TypeSpec.Builder typeBuilder = TypeSpec.enumBuilder(generatedClass.className())
+            .addOriginatingElement(generatedClass.getOriginatingElement())
             .addModifiers(PUBLIC)
             .addSuperinterface(QueryParameters.class)
             .addAnnotation(AnnotationSpec.builder(Generated.class)

--- a/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/functions/MappingToDotTest.java
+++ b/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/functions/MappingToDotTest.java
@@ -7,21 +7,23 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import javax.lang.model.element.TypeElement;
 import java.util.Map;
 
 import static fr.vidal.oss.jax_rs_linker.functions.MappingToDot.TO_DOT_STATEMENT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MappingToDotTest {
 
     @Mock
-    Map.Entry<ClassName, Mapping> entry;
+    Map.Entry<ClassNameGeneration, Mapping> entry;
 
     @Test
     public void maps_subresource_mapping_to_dot_statement() {
-        ClassName bar = ClassName.valueOf("com.acme.Bar");
+        ClassNameGeneration bar = new ClassNameGeneration(ClassName.valueOf("com.acme.Bar"), mock(TypeElement.class));
         when(entry.getKey()).thenReturn(bar);
         when(entry.getValue()).thenReturn(new Mapping(
                 new JavaLocation(bar, "dealWithIt"),
@@ -38,7 +40,7 @@ public class MappingToDotTest {
 
     @Test
     public void maps_self_mapping_to_null() {
-        ClassName bar = ClassName.valueOf("com.acme.Bar");
+        ClassNameGeneration bar = new ClassNameGeneration(ClassName.valueOf("com.acme.Bar"), mock(TypeElement.class));
         when(entry.getKey()).thenReturn(bar);
         when(entry.getValue()).thenReturn(new Mapping(
                 new JavaLocation(bar, "dealWithIt"),

--- a/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/parser/ElementParserTest.java
+++ b/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/parser/ElementParserTest.java
@@ -47,7 +47,7 @@ public class ElementParserTest {
         Mapping mapping = parser.parse(method).get();
 
         JavaLocation javaLocation = mapping.getJavaLocation();
-        assertThat(javaLocation.getClassName().fullyQualifiedName())
+        assertThat(javaLocation.getClassNameGeneration().getClassName().fullyQualifiedName())
             .isEqualTo("fr.vidal.oss.jax_rs_linker.parser.ProductResource");
         assertThat(javaLocation.getMethodName())
             .isEqualTo("productById");
@@ -73,7 +73,7 @@ public class ElementParserTest {
         Mapping mapping = parser.parse(method).get();
 
         JavaLocation javaLocation = mapping.getJavaLocation();
-        assertThat(javaLocation.getClassName().fullyQualifiedName())
+        assertThat(javaLocation.getClassNameGeneration().getClassName().fullyQualifiedName())
             .isEqualTo("fr.vidal.oss.jax_rs_linker.parser.ProductResource");
         assertThat(javaLocation.getMethodName())
             .isEqualTo("productById");

--- a/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/writer/DotFileWriterTest.java
+++ b/jax-rs-linker-processor/src/test/java/fr/vidal/oss/jax_rs_linker/writer/DotFileWriterTest.java
@@ -3,14 +3,23 @@ package fr.vidal.oss.jax_rs_linker.writer;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import fr.vidal.oss.jax_rs_linker.model.*;
+import fr.vidal.oss.jax_rs_linker.model.Api;
+import fr.vidal.oss.jax_rs_linker.model.ApiPath;
+import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.ClassNameGeneration;
+import fr.vidal.oss.jax_rs_linker.model.HttpVerb;
+import fr.vidal.oss.jax_rs_linker.model.JavaLocation;
+import fr.vidal.oss.jax_rs_linker.model.Mapping;
+import fr.vidal.oss.jax_rs_linker.model.SubResourceTarget;
 import org.junit.After;
 import org.junit.Test;
 
+import javax.lang.model.element.TypeElement;
 import java.io.StringWriter;
 
 import static fr.vidal.oss.jax_rs_linker.model.ApiLink.SUB_RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class DotFileWriterTest {
 
@@ -33,12 +42,13 @@ public class DotFileWriterTest {
         writer.close();
     }
 
-    private Multimap<ClassName, Mapping> mappings() {
-        HashMultimap<ClassName, Mapping> multimap = HashMultimap.create();
+    private Multimap<ClassNameGeneration, Mapping> mappings() {
+        HashMultimap<ClassNameGeneration, Mapping> multimap = HashMultimap.create();
+        ClassNameGeneration foo = new ClassNameGeneration(ClassName.valueOf("com.acme.Foo"), mock(TypeElement.class));
         multimap.put(
-                ClassName.valueOf("com.acme.Foo"),
+                foo,
                 new Mapping(
-                        new JavaLocation(ClassName.valueOf("com.acme.Foo"), "doIt"),
+                        new JavaLocation(foo, "doIt"),
                         new Api(
                                 HttpVerb.GET,
                                 SUB_RESOURCE(new SubResourceTarget(ClassName.valueOf("com.acme.Bar"), "")),


### PR DESCRIPTION
It helps with incremental compilation.

ContextPathHolder generation has been moved to ExposedApplicationAnnotationProcessor
to originate from the @ExposedApplication annotated type. It may be moved to a non
generated class which discover ApplicationName using SPI (https://docs.oracle.com/javase/tutorial/sound/SPI-intro.html)
or anything else at runtime.

The Graph option has not been migrated, it doesn't declare originating elements when used.
More tests with Gradle will be done to see if it is necessary to handle it 😇.