### PR TITLE
Replace String.format by String concatenation

### DIFF
--- a/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/base/Preconditions.java
+++ b/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/base/Preconditions.java
@@ -1,10 +1,12 @@
 package fr.vidal.oss.jax_rs_linker.base;
 
+import java.util.function.Supplier;
+
 public class Preconditions {
 
-    public static void checkState(boolean expression, String errorMessage) {
+    public static void checkState(boolean expression, Supplier<String> errorMessage) {
         if (!expression) {
-            throw new IllegalStateException(errorMessage);
+            throw new IllegalStateException(errorMessage.get());
         }
     }
 

--- a/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/functions/QueryParametersToQueryString.java
+++ b/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/functions/QueryParametersToQueryString.java
@@ -22,6 +22,6 @@ public enum QueryParametersToQueryString implements Function<Map<String,Collecti
                 builder.append(key).append("=").append(value).append("&");
             }
         }
-        return builder.toString().substring(0, builder.length() - 1);
+        return builder.substring(0, builder.length() - 1);
     }
 }

--- a/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/model/TemplatedUrl.java
+++ b/jax-rs-linker-api/src/main/java/fr/vidal/oss/jax_rs_linker/model/TemplatedUrl.java
@@ -1,20 +1,19 @@
 package fr.vidal.oss.jax_rs_linker.model;
 
+import static fr.vidal.oss.jax_rs_linker.base.Preconditions.checkState;
+import static fr.vidal.oss.jax_rs_linker.functions.QueryParametersToQueryString.TO_QUERY_STRING;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
 import fr.vidal.oss.jax_rs_linker.api.PathParameters;
 import fr.vidal.oss.jax_rs_linker.api.QueryParameters;
 import fr.vidal.oss.jax_rs_linker.predicates.PathParameterPredicate;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import static fr.vidal.oss.jax_rs_linker.base.Preconditions.checkState;
-import static fr.vidal.oss.jax_rs_linker.functions.QueryParametersToQueryString.TO_QUERY_STRING;
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
 
 public class TemplatedUrl<T extends PathParameters, U extends QueryParameters> {
 
@@ -37,7 +36,7 @@ public class TemplatedUrl<T extends PathParameters, U extends QueryParameters> {
     }
 
     public TemplatedUrl<T,U> replace(T parameter, String value) {
-        checkState(!pathParameters.isEmpty(), "No more path parameters to replace");
+        checkState(!pathParameters.isEmpty(), () -> "No more path parameters to replace");
         validateParamValue(parameter.regex(), value);
 
         return new TemplatedUrl<>(
@@ -63,7 +62,7 @@ public class TemplatedUrl<T extends PathParameters, U extends QueryParameters> {
     }
 
     public String value() {
-        checkState(pathParameters.isEmpty(), format("Parameters to replace: %s", parameterNames()));
+        checkState(pathParameters.isEmpty(), () -> format("Parameters to replace: %s", parameterNames()));
         return path + TO_QUERY_STRING.apply(queryParameters);
     }
 
@@ -80,7 +79,7 @@ public class TemplatedUrl<T extends PathParameters, U extends QueryParameters> {
     }
 
     private String placeholder(String name) {
-        return format("{%s}", name);
+        return "{" + name + "}";
     }
 
 }

--- a/jax-rs-linker-api/src/test/java/fr/vidal/oss/jax_rs_linker/base/PreconditionsTest.java
+++ b/jax-rs-linker-api/src/test/java/fr/vidal/oss/jax_rs_linker/base/PreconditionsTest.java
@@ -11,7 +11,7 @@ public class PreconditionsTest {
 
     @Test
     public void do_not_throw_IllegalStateException_when_condition_is_true() {
-        Preconditions.checkState(true, "should not happen!");
+        Preconditions.checkState(true, () -> "should not happen!");
     }
 
     @Test
@@ -19,6 +19,6 @@ public class PreconditionsTest {
         thrown.expect(IllegalStateException.class);
         thrown.expectMessage("must fail!");
 
-        Preconditions.checkState(false, "must fail!");
+        Preconditions.checkState(false, () -> "must fail!");
     }
 }

--- a/jax-rs-linker-performance/pom.xml
+++ b/jax-rs-linker-performance/pom.xml
@@ -1,0 +1,105 @@
+<!--
+Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fr.vidal.oss</groupId>
+        <artifactId>jax-rs-linker-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jax-rs-linker-performance</artifactId>
+    <name>JMH benchmark</name>
+
+    <properties>
+        <jmh.version>1.35</jmh.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jax-rs-linker-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>microbenchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/jax-rs-linker-performance/src/main/java/fr/vidal/oss/DoNotUseTooMuchStringFormat.java
+++ b/jax-rs-linker-performance/src/main/java/fr/vidal/oss/DoNotUseTooMuchStringFormat.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2005, 2013, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package fr.vidal.oss;
+
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+
+import fr.vidal.oss.jax_rs_linker.api.PathParameters;
+import fr.vidal.oss.jax_rs_linker.api.QueryParameters;
+import fr.vidal.oss.jax_rs_linker.model.ClassName;
+import fr.vidal.oss.jax_rs_linker.model.PathParameter;
+import fr.vidal.oss.jax_rs_linker.model.QueryParameter;
+import fr.vidal.oss.jax_rs_linker.model.TemplatedUrl;
+import java.util.regex.Pattern;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Thread)
+public class DoNotUseTooMuchStringFormat {
+
+    private TemplatedUrl<PathParameters, QueryParameters> withParameters = new TemplatedUrl<>(
+        "/api/product/{id}",
+        singleton(new PathParameter(ClassName.valueOf("java.lang.Integer"), "id")),
+        singleton(new QueryParameter("aggregate"))
+    );
+
+    @Benchmark
+    public String with_path_and_query_parameters() {
+        return withParameters.replace(ProductParameters.ID, "42")
+            .append(ProductQueryParameters.AGGREGATE, "UNITS")
+            .value();
+    }
+
+    private TemplatedUrl<PathParameters, QueryParameters> withPathParameter = new TemplatedUrl<>(
+        "/api/product/{id}",
+        singleton(new PathParameter(ClassName.valueOf("java.lang.Integer"), "id")),
+        emptySet()
+    );
+
+    @Benchmark
+    public String with_path_parameter() {
+        return withPathParameter.replace(ProductParameters.ID, "42").value();
+    }
+
+    enum ProductParameters implements PathParameters {
+        ID;
+
+        @Override
+        public String placeholder() {
+            return "id";
+        }
+
+        @Override
+        public Pattern regex() {
+            return null;
+        }
+    }
+
+    enum ProductQueryParameters implements QueryParameters {
+        AGGREGATE("aggregate");
+
+        private final String value;
+
+        ProductQueryParameters(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+            .include(DoNotUseTooMuchStringFormat.class.getSimpleName())
+            .forks(1)
+            .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <module>jax-rs-linker-processor</module>
         <module>jax-rs-linker-integration-tests</module>
         <module>jax-rs-linker-coverage-report</module>
+        <module>jax-rs-linker-performance</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
In some heavy load TemplatedUrl class could be in a hot path and String.format can
represent like 10% of the time spent in the code 😢.

This commit replaces String#format usage with String concatenation or delay its usage when really needed.

https://cowtowncoder.medium.com/measuring-performance-of-java-string-format-or-lack-thereof-2e1c6a13362c